### PR TITLE
Shlex and compare_utils  integraton

### DIFF
--- a/src/marketplacecli/commands/subscriptionprofilecmds/subscriptionprofile_admins.py
+++ b/src/marketplacecli/commands/subscriptionprofilecmds/subscriptionprofile_admins.py
@@ -9,7 +9,7 @@ from marketplace.objects.marketplace import users
 from marketplacecli.utils import org_utils
 from marketplacecli.utils import marketplace_utils
 import pyxb
-
+import shlex
 
 class SubscriptionProfileAdmins(Cmd, CoreGlobal):
     """Manage subscription profile admins"""
@@ -36,7 +36,7 @@ class SubscriptionProfileAdmins(Cmd, CoreGlobal):
             # add arguments
             do_parser = self.arg_add()
             try:
-                do_args = do_parser.parse_args(args.split())
+                do_args = do_parser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
 
@@ -95,7 +95,7 @@ class SubscriptionProfileAdmins(Cmd, CoreGlobal):
             # add arguments
             do_parser = self.arg_remove()
             try:
-                do_args = do_parser.parse_args(args.split())
+                do_args = do_parser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
 

--- a/src/marketplacecli/commands/subscriptionprofilecmds/subscriptionprofile_roles.py
+++ b/src/marketplacecli/commands/subscriptionprofilecmds/subscriptionprofile_roles.py
@@ -9,7 +9,7 @@ from marketplace.objects.marketplace import roles
 from marketplacecli.utils import org_utils
 from marketplacecli.utils import marketplace_utils
 import pyxb
-
+import shlex
 
 class SubscriptionProfileRoles(Cmd, CoreGlobal):
     """Manage subscription profile roles"""
@@ -36,7 +36,7 @@ class SubscriptionProfileRoles(Cmd, CoreGlobal):
             # add arguments
             do_parser = self.arg_add()
             try:
-                do_args = do_parser.parse_args(args.split())
+                do_args = do_parser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
 
@@ -93,7 +93,7 @@ class SubscriptionProfileRoles(Cmd, CoreGlobal):
             # add arguments
             do_parser = self.arg_remove()
             try:
-                do_args = do_parser.parse_args(args.split())
+                do_args = do_parser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
 

--- a/src/marketplacecli/commands/subscriptionprofilecmds/subscriptionprofilecmds.py
+++ b/src/marketplacecli/commands/subscriptionprofilecmds/subscriptionprofilecmds.py
@@ -11,7 +11,7 @@ from subscriptionprofile_admins import SubscriptionProfileAdmins
 from subscriptionprofile_roles import SubscriptionProfileRoles
 from marketplacecli.utils import marketplace_utils
 import pyxb
-
+import shlex
 
 class SubscriptionProfileCmds(Cmd, CoreGlobal):
     """Manage subscription profiles : list profile, create profiles, update profiles"""
@@ -43,7 +43,7 @@ class SubscriptionProfileCmds(Cmd, CoreGlobal):
             if args:
                 do_parser = self.arg_list()
                 try:
-                    do_args = do_parser.parse_args(args.split())
+                    do_args = do_parser.parse_args(shlex.split(args))
                 except SystemExit as e:
                     return
                 org_name = do_args.org
@@ -87,7 +87,7 @@ class SubscriptionProfileCmds(Cmd, CoreGlobal):
             # add arguments
             do_parser = self.arg_info()
             try:
-                do_args = do_parser.parse_args(args.split())
+                do_args = do_parser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
 
@@ -153,7 +153,7 @@ class SubscriptionProfileCmds(Cmd, CoreGlobal):
             # add arguments
             do_parser = self.arg_create()
             try:
-                do_args = do_parser.parse_args(args.split())
+                do_args = do_parser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
 
@@ -224,7 +224,7 @@ class SubscriptionProfileCmds(Cmd, CoreGlobal):
             # add arguments
             do_parser = self.arg_delete()
             try:
-                do_args = do_parser.parse_args(args.split())
+                do_args = do_parser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
 
@@ -271,7 +271,7 @@ class SubscriptionProfileCmds(Cmd, CoreGlobal):
             # add arguments
             do_parser = self.arg_update()
             try:
-                do_args = do_parser.parse_args(args.split())
+                do_args = do_parser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
 

--- a/src/marketplacecli/commands/usercmds/user_admin_cmds.py
+++ b/src/marketplacecli/commands/usercmds/user_admin_cmds.py
@@ -8,6 +8,7 @@ from marketplacecli.utils import org_utils
 from ussclicore.utils import printer
 from ussclicore.utils import generics_utils
 from marketplacecli.utils import marketplace_utils
+import shlex
 
 
 class UserAdminCmds(Cmd, CoreGlobal):
@@ -33,7 +34,7 @@ class UserAdminCmds(Cmd, CoreGlobal):
     def do_promote(self, args):
         try:
             doParser = self.arg_promote()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
             orgSpecified = org_utils.org_get(api=self.api, name=doArgs.org)
 
             adminUser = self.api.Users(doArgs.account).Get()
@@ -84,7 +85,7 @@ class UserAdminCmds(Cmd, CoreGlobal):
     def do_demote(self, args):
         try:
             doParser = self.arg_demote()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
             orgSpecified = org_utils.org_get(api=self.api, name=doArgs.org)
 
             adminUser = self.api.Users(doArgs.account).Get()

--- a/src/marketplacecli/commands/usercmds/user_role_cmds.py
+++ b/src/marketplacecli/commands/usercmds/user_role_cmds.py
@@ -7,6 +7,7 @@ from marketplace.objects.marketplace import *
 from marketplacecli.utils import org_utils
 from ussclicore.utils import printer
 from marketplacecli.utils import marketplace_utils
+import shlex
 
 
 class UserRoleCmds(Cmd, CoreGlobal):
@@ -33,7 +34,7 @@ class UserRoleCmds(Cmd, CoreGlobal):
             # add arguments
             do_parser = self.arg_list()
             try:
-                do_args = do_parser.parse_args(args.split())
+                do_args = do_parser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
 
@@ -74,7 +75,7 @@ class UserRoleCmds(Cmd, CoreGlobal):
         try:
             do_parser = self.arg_add()
             try:
-                do_args = do_parser.parse_args(args.split())
+                do_args = do_parser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
 
@@ -142,7 +143,7 @@ class UserRoleCmds(Cmd, CoreGlobal):
             # add arguments
             do_parser = self.arg_remove()
             try:
-                do_args = do_parser.parse_args(args.split())
+                do_args = do_parser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
 

--- a/src/marketplacecli/commands/usercmds/usercmds.py
+++ b/src/marketplacecli/commands/usercmds/usercmds.py
@@ -10,6 +10,7 @@ from marketplacecli.utils import marketplace_utils
 from marketplace.objects.marketplace import *
 from user_admin_cmds import UserAdminCmds
 from user_role_cmds import UserRoleCmds
+import shlex
 
 
 class UserCmds(Cmd, CoreGlobal):
@@ -81,7 +82,7 @@ class UserCmds(Cmd, CoreGlobal):
             # add arguments
             do_parser = self.arg_create()
             try:
-                do_args = do_parser.parse_args(args.split())
+                do_args = do_parser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
 
@@ -175,7 +176,7 @@ class UserCmds(Cmd, CoreGlobal):
     def do_enable(self, args):
         try:
             doParser = self.arg_enable()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
 
             printer.out("Enabling user [" + doArgs.account + "] ...")
             user = self.api.Users(doArgs.account).Get()
@@ -222,7 +223,7 @@ class UserCmds(Cmd, CoreGlobal):
     def do_disable(self, args):
         try:
             doParser = self.arg_disable()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
 
             printer.out("Disabling user [" + doArgs.account + "] ...")
             user = self.api.Users(doArgs.account).Get()

--- a/src/marketplacecli/commands/vendorcmds/vendorcmds.py
+++ b/src/marketplacecli/commands/vendorcmds/vendorcmds.py
@@ -8,6 +8,7 @@ from ussclicore.utils import printer
 from ussclicore.utils import generics_utils
 from marketplacecli.utils import marketplace_utils
 from marketplace.objects.marketplace import *
+import shlex
 
 
 class VendorCmds(Cmd, CoreGlobal):
@@ -30,7 +31,7 @@ class VendorCmds(Cmd, CoreGlobal):
         try:
             # add arguments
             do_parser = self.arg_list()
-            do_args = do_parser.parse_args(args.split())
+            do_args = do_parser.parse_args(shlex.split(args))
 
             # call UForge API
             printer.out("Getting vendors ...")

--- a/src/marketplacecli/utils/compare_utils.py
+++ b/src/marketplacecli/utils/compare_utils.py
@@ -1,0 +1,58 @@
+__author__ = 'UShareSoft'
+
+"""
+     * Compare a list values attributs with a given value to return
+     * a new list that include only the matched values.
+     *
+     * @param list               The list to analyse first
+     * @param values             The values the attributs will be compared to.
+     * @param attrName           Name of the object's attribut that will be compared.
+     *                           Normally in list but if otherList is filled it's in
+     *                           otherlist.
+     * @param subattrName        If needed, parameter that allows to check a sub-attribut
+     *                           from attrName.
+     * @param otherList          In case a match is necessary with cross-lists, fill this
+     *                           parameter with the second list where the attribut enquired
+     *                           is.
+     * @param linkProperties     List of two items that correspond to the two attribut that
+     *                           links the two lists. item[0] is in list and item[1] is in
+     *                           otherList.
+     * @see User
+"""
+# Library that supports the Unix matching systems
+import fnmatch
+
+
+def compare(list, values, attrName, subattrName=None, otherList=None, linkProperties=None):
+
+        if len(values) == 0:
+                return Exception
+
+        # List to return
+        returnList = []
+
+        for value in values:
+                for item in list:
+                        if otherList is None:
+                                # Get attribut "attrName" at first level
+                                compareName = getattr(item, attrName)
+                                if subattrName is None:
+                                        if fnmatch.fnmatch(compareName, value):
+                                                returnList.append(item)
+                                # If sub attribute requested, get it
+                                else:
+                                        compareName2 = getattr(compareName, subattrName)
+                                        if fnmatch.fnmatch(compareName2, value):
+                                                returnList.append(item)
+                        else:
+                                for otherItem in otherList:
+                                        if getattr(item, linkProperties[0]) == getattr(otherItem, linkProperties[1]):
+                                                compareName = getattr(otherItem, attrName)
+                                                if subattrName is None:
+                                                        if fnmatch.fnmatch(compareName, value):
+                                                                returnList.append(item)
+                                                else:
+                                                        compareName2 = getattr(compareName, subattrName)
+                                                        if fnmatch.fnmatch(compareName2, value):
+                                                                returnList.append(item)
+        return returnList

--- a/src/marketplacecli/utils/marketplace_utils.py
+++ b/src/marketplacecli/utils/marketplace_utils.py
@@ -30,7 +30,7 @@ def print_uforge_exception(e):
 
 def handle_uforge_exception(e):
     print_uforge_exception(e)
-    return 1
+    return 2
 
 
 def handle_bad_parameters(cmd, e):


### PR DESCRIPTION
Shlex :
This module is meant to preserve Unix command usage because args.split() wasn't efficient. For example it was splitting an argument like --description "Good Morning !" in a tuple like this "Good", "Morning", "!".
Shlex corrects this and adds new possibilities.

compare_utils :
The utils uses fnmatch so you can use wildcard and multiple argument on a basic nargs='+' argument.